### PR TITLE
Remove kout deprecation (https://github.com/karaxnim/karax/issues/182)

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -7,9 +7,8 @@ export kdom.Event, kdom.Blob
 when defined(nimNoNil):
   {.experimental: "notnil".}
 
-proc kout*[T](x: T) {.importc: "console.log", varargs, deprecated.}
-  ## the preferred way of debugging karax applications. Now deprecated,
-  ## you can now use ``system.echo`` instead.
+proc kout*[T](x: T) {.importc: "console.log", varargs.}
+  ## The preferred way of debugging karax applications.
 
 type
   PatchKind = enum


### PR DESCRIPTION
I agree with @planetis-m, `kout` tends to be much more useful for print style debugging is when compared with `echo`, and sometimes is the best way to deal with printing JsObjects from external JS libraries as well.