### PR TITLE
Typo fix

### DIFF
--- a/experiments/refs/demo.nim
+++ b/experiments/refs/demo.nim
@@ -1,4 +1,4 @@
-include karaxprelude
+include karax/prelude
 import future, sequtils
 
 type


### PR DESCRIPTION
A fix to a typo. The slash was missing.