### PR TITLE
Pin dotenv so build can succeed

### DIFF
--- a/karax.nimble
+++ b/karax.nimble
@@ -9,7 +9,7 @@ license       = "MIT"
 
 requires "nim >= 0.18.0"
 requires "ws"
-requires "dotenv"
+requires "dotenv == 1.1.1"
 skipDirs = @["examples", "experiments", "tests"]
 
 bin = @["karax/tools/karun"]


### PR DESCRIPTION
I tried to build this project and got an error `/karax/tools/static_server.nim(114, 14) Error: undeclared identifier: 'DotEnv'`, apparently relating to yesterday's (!)  [redesign of `euantorano/dotenv.nim`](https://github.com/euantorano/dotenv.nim/commit/d80c0f07c51a74ecd570a227c4d733525c4debfb). I pinned the dependency to allow karax to build. Will look at accommodating new dotenv design if I get time.