### PR TITLE
Updated dotenv dependency to 2.0.0.

### DIFF
--- a/karax.nimble
+++ b/karax.nimble
@@ -9,7 +9,7 @@ license       = "MIT"
 
 requires "nim >= 0.18.0"
 requires "ws"
-requires "dotenv"
+requires "dotenv >= 2.0.0"
 skipDirs = @["examples", "experiments", "tests"]
 
 bin = @["karax/tools/karun"]

--- a/karax/tools/static_server.nim
+++ b/karax/tools/static_server.nim
@@ -111,9 +111,7 @@ proc handleWs(req: Request) {.async.} =
 
 proc serveStatic*() =
   if fileExists("static.env"):
-    var env: DotEnv
-    env = initDotEnv(getCurrentDir(), "static.env")
-    env.overload()
+    overload(getCurrentDir(), "static.env")
   else:
     putEnv("staticDir", "assets/")
 


### PR DESCRIPTION
This supersedes #217 

Updated `dotenv` to 2.0.0, which has hanged its API for loading environment files. I've also added a version constraint to the Nimble file.