### PR TITLE
Fix #232

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -520,7 +520,7 @@ proc diff(newNode, oldNode: VNode; parent, current: Node; kxi: KaraxInstance) =
     let pos = min(oldPos, newPos) + 1
     # now the different children are in commonPrefix .. pos - 1:
     for i in commonPrefix..pos-1:
-      diff(newNode[i], oldNode[i], current, current.childNodes[i], kxi)
+      diff(newNode[i], oldNode[i], current, oldNode[i].dom, kxi)
 
     if oldPos + 1 == oldLength:
       for i in pos..newPos:
@@ -665,7 +665,8 @@ proc dodraw(kxi: KaraxInstance) =
     let asdom = toDom(newtree, useAttachedNode = true, kxi)
     replaceById(kxi.rootId, asdom)
   else:
-    doAssert same(kxi.currentTree, document.getElementById(kxi.rootId))
+    when not defined(release):
+      doAssert same(kxi.currentTree, document.getElementById(kxi.rootId))
     let olddom = document.getElementById(kxi.rootId)
     diff(newtree, kxi.currentTree, nil, olddom, kxi)
   when defined(profileKarax):
@@ -678,7 +679,8 @@ proc dodraw(kxi: KaraxInstance) =
     echo ">>>>>>>>>>>>>>"
   applyPatch(kxi)
   kxi.currentTree = newtree
-  doAssert same(kxi.currentTree, document.getElementById(kxi.rootId))
+  when not defined(release):
+    doAssert same(kxi.currentTree, document.getElementById(kxi.rootId))
 
   if not kxi.postRenderCallback.isNil:
     kxi.postRenderCallback(rdata)


### PR DESCRIPTION
Fixes issue #232 (Broken functionalities when karax used with grammarly or languagetool (and possibly other extensions))

Switched off the assertions that were triggering (only on release)

Changed the diff procedure to use the stored dom nodes (in vdom) instead of getting them from the dom (where they are now not in the expected order)

Tested on some manual recreations of the issue (inserting new elements before/inbetween/after nodes managed by karax) and on the test suite