### PR TITLE
add example using kajax to load data

### DIFF
--- a/examples/ajax/ajax.nim
+++ b/examples/ajax/ajax.nim
@@ -1,0 +1,73 @@
+
+##[
+  An example that uses ajax to load the nim package list and display a simple searchable index
+]##
+
+import karax/[karax, karaxdsl, vdom, jstrutils, kajax, jjson]
+
+type
+  Package = object
+    name, description, url: cstring
+
+  Progress = enum
+    Loading,
+    Loaded
+
+  AppState = object
+    progress: Progress
+    packages: seq[Package]
+    searchText: cstring
+
+var state = AppState()
+
+proc init =
+  # start a request to get the package list from github
+  ajaxGet("https://raw.githubusercontent.com/nim-lang/packages/master/packages.json", @[], proc (status: int, response: cstring) =
+    for json in parse(response):
+      # only add entries that aren't aliases
+      if not json.hasField("alias"):
+        state.packages.add(Package(
+          name: json["name"].getStr(),
+          description: json["description"].getStr(),
+          url: json["url"].getStr()
+        ))
+    state.progress = Loaded
+  )
+
+proc drawPackage(package: Package): VNode =
+  buildHtml(tdiv(class="result")):
+    h2:
+      a(href=package.url):
+        text package.name
+    p: text package.description
+
+proc loadingView: VNode =
+  buildHtml(tdiv):
+    h1: text "Loading..."
+
+proc searchView: VNode =
+  buildHtml(tdiv):
+    h1: text "Search"
+    input:
+      proc onkeyup(e: Event, n: VNode) =
+        state.searchText = n.value
+
+    # we show up to 50 packages that match the search text. If the input is
+    # empty, we just show the first 50 packages in the list
+    var found = 0
+
+    for package in state.packages:
+      if state.searchText.len == 0 or package.name.contains(state.searchText) or package.description.contains(state.searchText):
+        drawPackage(package)
+        inc found
+        if found > 50:
+          break
+
+proc main: VNode =
+  if state.progress == Loading:
+    loadingView()
+  else:
+    searchView()
+
+setRenderer(main)
+init()

--- a/examples/ajax/styles.css
+++ b/examples/ajax/styles.css
@@ -1,0 +1,15 @@
+
+body {
+  max-width: 60em;
+  margin: 0 auto;
+  font-family: sans-serif;
+}
+
+input {
+  font-size: 1.5em;
+  padding: .4em .6em;
+}
+
+.result h2 {
+  margin-top: 2em;
+}

--- a/karax/jjson.nim
+++ b/karax/jjson.nim
@@ -11,6 +11,9 @@ proc `[]=`*[T](obj: JsonNode; fieldname: cstring; value: T)
 proc length(x: JsonNode): int {.importcpp: "#.length".}
 proc len*(x: JsonNode): int = (if x.isNil: 0 else: x.length)
 
+proc parse*(input: cstring): JsonNode {.importcpp: "JSON.parse(#)".}
+proc hasField*(obj: JsonNode; fieldname: cstring): bool {.importcpp: "#[#] !== undefined".}
+
 proc newJsonNode*(fields: varargs[(cstring, JsonNode)]): JsonNode =
   result = JsonNode()
   for f in fields:


### PR DESCRIPTION
This PR adds a simple example that uses ajaxGet to load the nim package list and show a searchable list of packages

![image](https://user-images.githubusercontent.com/1889120/212405050-6242bd1d-4700-474c-8487-a7d8ff7cfe0c.png)

I also added two new procs to jjson that seemed useful enough to include there, and are used in the example
