### PR TITLE
Add boolean version of setAttr

### DIFF
--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -250,6 +250,15 @@ proc setAttr*(n: VNode; key: kstring; val: kstring = "") =
     n.attrs.add key
     n.attrs.add val
 
+proc setAttr*(n: VNode, key: kstring, val: bool) =
+  if val:
+    n.setAttr(key, "")
+  else:
+    for i in countup(0, n.attrs.len-2, 2):
+      if n.attrs[i] == key:
+        n.attrs.delete i+1
+        n.attrs.delete i
+
 proc getAttr*(n: VNode; key: kstring): kstring =
   for i in countup(0, n.attrs.len-2, 2):
     if n.attrs[i] == key: return n.attrs[i+1]

--- a/readme.md
+++ b/readme.md
@@ -315,6 +315,25 @@ setError password, password & " must not be empty"
 ```
 There are likely more elegant solutions to this problem.
 
+## Boolean attributes
+
+Some HTML attributes don't have meaningful values; instead, they are treated like
+a boolean whose value is `false` when the attribute is not set, and `true` when
+the value is set to any value. Some examples of these attributes are `disabled`
+and `contenteditable`.
+
+In Karax, these attributes can be set/cleared with a boolean value:
+
+```nim
+proc submitButton(dataIsValid: bool): VNode =
+  buildHtml(tdiv):
+    button(disabled = not dataIsValid):
+      if dataIsValid:
+        text "Submit"
+      else:
+        text "Cannot submit, data is invalid!"
+```
+
 ## Routing
 
 

--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,7 @@ There are likely more elegant solutions to this problem.
 
 Some HTML attributes don't have meaningful values; instead, they are treated like
 a boolean whose value is `false` when the attribute is not set, and `true` when
-the value is set to any value. Some examples of these attributes are `disabled`
+the attribute is set to any value. Some examples of these attributes are `disabled`
 and `contenteditable`.
 
 In Karax, these attributes can be set/cleared with a boolean value:


### PR DESCRIPTION
Related issue: https://github.com/karaxnim/karax/issues/239

This PR adds a new `setAttr` proc, which accepts a boolean value instead of a string. When the value is `true`, it's the same thing as doing `vnode.setAttr("key", val = "")`. When the value is `false`, it iterates through `VNode.attrs` and deletes the attribute, if it exists.

The net effect of this new proc is that it is much easier to deal with attributes that need to be dynamically added/removed from the VDOM.

Example:

```nim
proc submitButton(dataIsValid: bool): VNode =
  buildHtml(tdiv):
    button(disabled = not dataIsValid):
      if dataIsValid:
        text "Submit"
      else:
        text "Cannot submit, data is invalid!"
```