### PR TITLE
Add missing html tags

### DIFF
--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -62,7 +62,7 @@ type
     keygen, output, progress, meter,
     details, summary, command, menu,
 
-    b, bdo, dialog, i, kbd, s, slot, `template`="template", u
+    bdo, dialog, kbd, slot, `template`="template"
 
 const
   selfClosing = {area, base, br, col, embed, hr, img, input,

--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -60,7 +60,9 @@ type
     form, fieldset, legend, label, input, button,
     select, datalist, optgroup, option, textarea,
     keygen, output, progress, meter,
-    details, summary, command, menu
+    details, summary, command, menu,
+
+    b, bdo, dialog, i, kbd, s, slot, `template`="template", u
 
 const
   selfClosing = {area, base, br, col, embed, hr, img, input,


### PR DESCRIPTION
Checked against the [MDN list](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference) of valid, non-deprecated tags. Supercedes #235. Ready to merge