### PR TITLE
Fix vnode event move

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -147,6 +147,10 @@ proc applyEvents(n: VNode) =
   for i in 0..<len(n.events):
     n.events[i][2] = wrapEvent(dest, n, n.events[i][0], n.events[i][1])
 
+proc reapplyEvents(n: VNode) =
+  removeAllEventHandlers(n.dom)
+  applyEvents(n)
+
 proc getVNodeById*(id: cstring; kxi: KaraxInstance = kxi): VNode =
   ## Get the VNode that was marked with ``id``. Returns ``nil``
   ## if no node exists.
@@ -388,6 +392,7 @@ proc addPatchV(kxi: KaraxInstance; parent: VNode; pos: int; newChild: VNode) =
 proc moveDom(dest, src: VNode) =
   dest.dom = src.dom
   src.dom = nil
+  reapplyEvents(dest)
   if dest.id != nil:
     kxi.byId[dest.id] = dest
   assert dest.len == src.len


### PR DESCRIPTION
This PR adds a `reapplyEvents` proc (called during `moveDom`) that removes event handlers from the attached dom element, then reapplies them pointing to the new vnode. This is necessary because after diffing the new vnode now owns the attached dom element.

This approach feels a little costly as the handlers must be replaced on each diff. I initially tried to instead attach the vdom to the dom node so that the event wrapper could use that, and the vnode could be updated, but that did not work. What are your thoughts @Araq?

This would solve #254 and #117 