### PR TITLE
Add query string and fix hash

### DIFF
--- a/karax/jstrutils.nim
+++ b/karax/jstrutils.nim
@@ -31,3 +31,5 @@ proc isInt*(s: cstring): bool {.asmNoStackFrame.} =
 
 proc parseInt*(s: cstring): int {.importcpp: "parseInt(#, 10)", nodecl.}
 proc parseFloat*(s: cstring): BiggestFloat {.importc, nodecl.}
+
+proc join*(a: openArray[cstring], sep = cstring""): cstring {.importcpp: "(#.join(#))", nodecl.}


### PR DESCRIPTION
I noticed `hashPart` ate the query string, which is not good for routing, so I decided to fix it. `RouterData` now has `hashPart` and `queryString`. One has the hash "path", the other has the search string