### PR TITLE
unified patch for namespaced tags

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -195,11 +195,11 @@ proc toDom*(n: VNode; useAttachedNode: bool; kxi: KaraxInstance = nil): Node =
     attach n
     return result
   else: # we are dealing with fundamental tags at this point, and not nim components/functions
-    if svgElements.contains(n.kind):
-      result = document.createElementNS(svgNamespace,toTag[n.kind]) #svg elements need to be declared with a namespace
+    if (svgElements*needingNamespace).contains(n.kind):
+      result = document.createElementNS(svgNamespace,toTag[n.kind]) #svg top-level elements need to be declared with a namespace
       #we apply a default so that users can just treat it like html in the DSL while learning 
     
-    elif mathElements.contains(n.kind): #mathML needs a similar treatment as svg
+    elif (mathElements*needingNamespace}.contains(n.kind): #mathML needs a similar treatment as svg
       result = document.createElementNS(mathNamespace,toTag[n.kind])
     else:
       result = document.createElement(toTag[n.kind])

--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -194,8 +194,15 @@ proc toDom*(n: VNode; useAttachedNode: bool; kxi: KaraxInstance = nil): Node =
     result = toDom(x.expanded, useAttachedNode, kxi)
     attach n
     return result
-  else:
-    result = document.createElement(toTag[n.kind])
+  else: # we are dealing with fundamental tags at this point, and not nim components/functions
+    if svgElements.contains(n.kind):
+      result = document.createElementNS(svgNamespace,toTag[n.kind]) #svg elements need to be declared with a namespace
+      #we apply a default so that users can just treat it like html in the DSL while learning 
+    
+    elif mathElements.contains(n.kind): #mathML needs a similar treatment as svg
+      result = document.createElementNS(mathNamespace,toTag[n.kind])
+    else:
+      result = document.createElement(toTag[n.kind])
     attach n
     for k in n:
       appendChild(result, toDom(k, useAttachedNode, kxi))

--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -199,7 +199,7 @@ proc toDom*(n: VNode; useAttachedNode: bool; kxi: KaraxInstance = nil): Node =
       result = document.createElementNS(svgNamespace,toTag[n.kind]) #svg top-level elements need to be declared with a namespace
       #we apply a default so that users can just treat it like html in the DSL while learning 
     
-    elif (mathElements*needingNamespace}.contains(n.kind): #mathML needs a similar treatment as svg
+    elif (mathElements*needingNamespace).contains(n.kind): #mathML needs a similar treatment as svg
       result = document.createElementNS(mathNamespace,toTag[n.kind])
     else:
       result = document.createElement(toTag[n.kind])

--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -69,8 +69,9 @@ const
     link, meta, param, source, track, wbr}
     
 const
-  svgElements = {animate..view}    
+  svgElements = {animate..view}
   mathElements = {maction..semantics}
+  needingNamespace = {svg,math}
     
 var 
   svgNamespace* = "http://www.w3.org/2000/svg"

--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -69,9 +69,9 @@ const
     link, meta, param, source, track, wbr}
     
 const
-  svgElements = {animate..view}
-  mathElements = {maction..semantics}
-  needingNamespace = {svg,math}
+  svgElements* = {animate..view}
+  mathElements* = {maction..semantics}
+  needingNamespace* = {svg,math}
     
 var 
   svgNamespace* = "http://www.w3.org/2000/svg"

--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -67,6 +67,16 @@ type
 const
   selfClosing = {area, base, br, col, embed, hr, img, input,
     link, meta, param, source, track, wbr}
+    
+const
+  svgElements = {animate..view}    
+  mathElements = {maction..semantics}
+    
+var 
+  svgNamespace* = "http://www.w3.org/2000/svg"
+  mathNamespace* = "http://www.w3.org/1998/Math/MathML"
+  #global var settings: defaults are already set up, but may be adjusted in one shot for the user's entire project
+
 
 type
   EventKind* {.pure.} = enum ## The events supported by the virtual DOM.


### PR DESCRIPTION
svg and mathML need to be written with namespaces specified by the xmls parameter.

[https://developer.mozilla.org/en-US/docs/Web/SVG/Namespaces_Crash_Course](url)

This patch defines mathML and svg element sets for future reference, and the needingNamespace elements that have to be declared with a namespace, as well as default namespaces for SVG and mathML.

This should set up math and svg elements to work just like regular html in the karax DSL. The global variable settings can be overridden without modifying the package if the user desires.