### PR TITLE
(dirty?) Multi backend support for JS style DSL

### DIFF
--- a/karax/karaxdsl.nim
+++ b/karax/karaxdsl.nim
@@ -4,6 +4,13 @@ from strutils import startsWith, toLowerAscii
 
 when defined(js):
   import karax
+else:
+  type
+    KaraxInstance = ref object
+  var kxi*: KaraxInstance ## The current Karax instance. This is always used
+  proc addEventHandler*(n: VNode; k: EventKind; action: EventHandler;
+                        kxi: KaraxInstance = kxi) = discard
+
 
 const
   StmtContext = ["kout", "inc", "echo", "dec", "!"]


### PR DESCRIPTION
This PR is just an PoC of how interesting will be if Karax DSL for JS backend works in C-like backend (ignoring events).

In this way, we can define just one renderer and render it in both sides, backend and frontend. This allows SSR for JS DSLs.

Working example: https://github.com/thisago/bothend


[**renderer.nim**](https://git.ozzuu.com/thisago/bothend/src/branch/master/src/renderer.nim)
```nim
include pkg/karax/prelude
[...]

var rows = @["Static row, available in both ends"]

proc render*(backend: bool): VNode =
  ## HTML Renderer for JS, allowed with events too!
  buildHtml(tdiv(id = "ROOT")):
    h1:
      text "Hello from " &
        (if backend: "backend" else: "frontend")
      proc onclick(ev: Event; n: VNode) =
        echo "clicked"
        rows.add "Frontend powers!"
    for row in rows:
      p: text row
    script(src = "script/frontend.js")
```

[**backend.nim**](https://git.ozzuu.com/thisago/bothend/src/branch/master/src/backend.nim)
```nim
# compile with: `nimble build_release`
import pkg/jester
import ./renderer

routes:
  get "/":
    resp baseHtml render(backend = true)
  get "/script/frontend.js":
    resp readFile "public/script/frontend.js"
```

[**frontend.nim**](https://git.ozzuu.com/thisago/bothend/src/branch/master/src/frontend.nim)
```nim
# compile with: `nimble build_js_release`
include pkg/karax/prelude
import ./renderer

proc renderPage: VNode =
  render(backend = false)

setRenderer renderPage
```