### PR TITLE
fix #268

### DIFF
--- a/karax/vdom.nim
+++ b/karax/vdom.nim
@@ -349,7 +349,7 @@ when kstring is cstring:
   proc len(a: kstring): int =
     # xxx: maybe move where kstring is defined
     # without this, `n.field.len` fails on js (non web) platform
-    if a == nil: 0 else: a.len
+    if a == nil: 0 else: system.len(a)
 
 template toStringAttr(field) =
   if n.field.len > 0:


### PR DESCRIPTION
Call the original len using `system.len` instead of calling the overload recursively, which leads to stack issues on JS targets.