### PR TITLE
fix(#200): use template element for verbatim

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -167,8 +167,9 @@ proc toDom*(n: VNode; useAttachedNode: bool; kxi: KaraxInstance = nil): Node =
     result = document.createTextNode(n.text)
     attach n
   elif n.kind == VNodeKind.verbatim:
-    result = document.createElement("div")
-    result.innerHTML = n.text
+    var t = document.createElement("template")
+    t.innerHTML = n.text
+    result = t.content
     attach n
     return result
   elif n.kind == VNodeKind.vthunk:


### PR DESCRIPTION
Closes https://github.com/karaxnim/karax/pull/160 and https://github.com/karaxnim/karax/issues/200.

Template's seem [well-supported](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) and I haven't found any problems testing locally. 

This also avoids the problem with #160 mentioned in this [reply](https://github.com/karaxnim/karax/issues/200#issuecomment-846568814) and properly handles children.