### PR TITLE
Revert "fix(#200): use template element for verbatim (#270)"

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -170,9 +170,8 @@ proc toDom*(n: VNode; useAttachedNode: bool; kxi: KaraxInstance = nil): Node =
     result = document.createTextNode(n.text)
     attach n
   elif n.kind == VNodeKind.verbatim:
-    var t = document.createElement("template")
-    t.innerHTML = n.text
-    result = t.content
+    result = document.createElement("div")
+    result.innerHTML = n.text
     attach n
     return result
   elif n.kind == VNodeKind.vthunk:


### PR DESCRIPTION
This reverts commit 8e0f471e6368c57645909f10cbcb64b0df037a09. (see issue #273 )