### PR TITLE
feature suggestion: {.noredraw.} pragma

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -829,6 +829,14 @@ proc addEventHandler*(n: VNode; k: EventKind; action: proc();
     if not kxi.surpressRedraws: redraw(kxi)
   addEventListener(n, k, wrapper)
 
+proc addEventHandlerNoRedraw*(n: VNode; k: EventKind; action: EventHandler) =
+  addEventListener(n, k, action)
+
+proc addEventHandlerNoRedraw*(n: VNode; k: EventKind; action: proc()) =
+  proc wrapper(ev: Event; n: VNode) =
+    action()
+  addEventListener(n, k, wrapper)
+
 proc setOnHashChange*(action: proc (hashPart: cstring)) {.deprecated: "use setRenderer instead".} =
   ## Now deprecated, instead pass a callback to ``setRenderer`` that receives
   ## a ``data: RouterData`` parameter.

--- a/karax/karaxdsl.nim
+++ b/karax/karaxdsl.nim
@@ -44,8 +44,17 @@ proc toKstring(n: NimNode): NimNode =
 proc newDotAsgn(tmp: NimNode, key: string, x: NimNode): NimNode =
   result = newTree(nnkAsgn, newDotExpr(tmp, newIdentNode key), x)
 
-proc handleNoRedrawPragma(call: NimNode, tmpContext, name, anon: NimNode): NimNode =
+when defined(js):
+  template evHandler(): untyped = bindSym"addEventHandler"
+else:
+  template evHandler(): untyped = ident"addEventHandler"
+
+proc genAddHandlerCall(tmpContext, n: NimNode): NimNode =
+  # turn it into an anon proc:
+  let anon = copyNimTree(n)
+  anon[0] = newEmptyNode()
   when defined(js):
+    # if has noredraw pragma add handler without redraw
     if anon.pragma.kind == nnkPragma and len(anon.pragma) > 0:
       var hasNoRedrawPragma = false
       for i in 0 ..< len(anon.pragma):
@@ -56,8 +65,10 @@ proc handleNoRedrawPragma(call: NimNode, tmpContext, name, anon: NimNode): NimNo
           break
       if hasNoRedrawPragma:
         return newCall(ident"addEventHandlerNoRedraw", tmpContext,
-                       newDotExpr(bindSym"EventKind", name), anon)
-  call
+                       newDotExpr(bindSym"EventKind", n[0]), anon)
+
+  newCall(evHandler(), tmpContext,
+          newDotExpr(bindSym"EventKind", n[0]), anon, ident("kxi"))
 
 proc tcall2(n, tmpContext: NimNode): NimNode =
   # we need to distinguish statement and expression contexts:
@@ -68,10 +79,6 @@ proc tcall2(n, tmpContext: NimNode): NimNode =
   # (except for the last child of the macros we consider here),
   # lets, consts, types can be considered as expressions
   # case is complex, calls are assumed to produce a value.
-  when defined(js):
-    template evHandler(): untyped = bindSym"addEventHandler"
-  else:
-    template evHandler(): untyped = ident"addEventHandler"
 
   case n.kind
   of nnkLiterals, nnkIdent, nnkSym, nnkDotExpr, nnkBracketExpr:
@@ -103,15 +110,10 @@ proc tcall2(n, tmpContext: NimNode): NimNode =
   of nnkProcDef:
     let name = getName n[0]
     if name.startsWith"on":
-      # turn it into an anon proc:
-      let anon = copyNimTree(n)
-      anon[0] = newEmptyNode()
       if tmpContext == nil:
         error "no VNode to attach the event handler to"
       else:
-        let call = newCall(evHandler(), tmpContext,
-                           newDotExpr(bindSym"EventKind", n[0]), anon, ident("kxi"))
-        result = handleNoRedrawPragma(call, tmpContext, n[0], anon)
+        result = genAddHandlerCall(tmpContext, n)
     else:
       result = n
   of nnkVarSection, nnkLetSection, nnkConstSection:

--- a/karax/karaxdsl.nim
+++ b/karax/karaxdsl.nim
@@ -57,7 +57,7 @@ proc handleNoRedrawPragma(call: NimNode, tmpContext, name, anon: NimNode): NimNo
       if hasNoRedrawPragma:
         return newCall(ident"addEventHandlerNoRedraw", tmpContext,
                        newDotExpr(bindSym"EventKind", name), anon)
-  call
+  result = call
 
 proc tcall2(n, tmpContext: NimNode): NimNode =
   # we need to distinguish statement and expression contexts:


### PR DESCRIPTION
There is currently no easy way to surpress redraw just for one specific handler (probably because it isnt needed very often).

You can `kxi.surpressRedraw = true` inside your handler, but then there is no way to set it back afterwards.
The only way currently is using `addEventListener` manually, which isnt very elegant.

So I added `addEventHandlerNoRedraw` procs to `karax.nim` and the `.noredraw.` pragma to the dsl syntax.
Now you just need to do:
```nim
buildHtml(..):
...
  proc onclick {.noredraw.} =
    dostuff
...
```
or
```nim
proc onclick(e: Event, n: VNode) {.noredraw.} =
  dostuff
```

maybe this would be nice to have in the repo