### PR TITLE
Add reactivity to the textarea kind VNodes.

### DIFF
--- a/karax/karax.nim
+++ b/karax/karax.nim
@@ -513,6 +513,10 @@ proc diff(newNode, oldNode: VNode; parent, current: Node; kxi: KaraxInstance) =
         let checked = newNode.getAttr("checked")
         oldNode.dom.checked = if checked.isNil: false else: true
 
+      # Set the value of the textarea field to update
+      if oldNode.kind == VNodeKind.textarea:
+        oldNode.dom.value = newNode.text
+
     if newNode.events.len != 0 or oldNode.events.len != 0:
       mergeEvents(newNode, oldNode, kxi)
 


### PR DESCRIPTION
Issue https://github.com/karaxnim/karax/issues/61 is also valid for `textarea`. Therefore, a fix similar to https://github.com/karaxnim/karax/pull/201 is proposed in this PR.