### PR TITLE
add touch events and tests

### DIFF
--- a/karax/kdom_impl.nim
+++ b/karax/kdom_impl.nim
@@ -869,10 +869,10 @@ type
   Touch* = ref TouchObj
   TouchObj {.importc.} = object of RootObj
     identifier*: int
-    screenX*, screenY*, clientX*, clientY*, pageX*, pageY*: float
+    screenX*, screenY*, clientX*, clientY*, pageX*, pageY*: int
     target*: Element
-    radiusX*, radiusY*: float
-    rotationAngle*: float
+    radiusX*, radiusY*: int
+    rotationAngle*: int
     force*: float
 
   # https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent

--- a/karax/kdom_impl.nim
+++ b/karax/kdom_impl.nim
@@ -35,6 +35,9 @@ type
     onreset*: proc (event: Event) {.nimcall.}
     onselect*: proc (event: Event) {.nimcall.}
     onsubmit*: proc (event: Event) {.nimcall.}
+    ontouchstart*: proc(event: Event) {.nimcall.}
+    ontouchmove*: proc(event: Event) {.nimcall.}
+    ontouchend*: proc(event: Event) {.nimcall.}
     onunload*: proc (event: Event) {.nimcall.}
 
   # https://developer.mozilla.org/en-US/docs/Web/Events
@@ -66,6 +69,7 @@ type
     Resize = "resize",
     Scroll = "scroll",
     Select = "select",
+    Touch = "touch"
     Unload = "unload",
     Wheel = "wheel"
 
@@ -865,15 +869,21 @@ type
   Touch* = ref TouchObj
   TouchObj {.importc.} = object of RootObj
     identifier*: int
-    screenX*, screenY*, clientX*, clientY*, pageX*, pageY*: int
+    screenX*, screenY*, clientX*, clientY*, pageX*, pageY*: float
     target*: Element
-    radiusX*, radiusY*: int
-    rotationAngle*: int
+    radiusX*, radiusY*: float
+    rotationAngle*: float
     force*: float
 
+  # https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
   TouchEvent* = ref TouchEventObj
   TouchEventObj {.importc.} = object of UIEvent
     changedTouches*, targetTouches*, touches*: seq[Touch]
+
+  TouchEventTypes* = enum
+    TouchStart = "touchstart",
+    TouchMove = "touchmove",
+    TouchEnd = "touchend"
 
   Location* = ref LocationObj
   LocationObj {.importc.} = object of RootObj

--- a/tests/domEventTests.css
+++ b/tests/domEventTests.css
@@ -1,10 +1,22 @@
 #dragDiv {
   background-color: #0d1224;
-  width: 500px;
+  width: 250px;
   height: 100px;
   position: absolute; 
   top: 500px;
   left: 200px;
+  text-align: center;
+  cursor: move;
+  color: rgb(60, 201, 163);
+}
+
+#touchDiv {
+  background-color: #0d1224;
+  width: 250px;
+  height: 100px;
+  position: absolute; 
+  top: 500px;
+  left: 500px;
   text-align: center;
   cursor: move;
   color: rgb(60, 201, 163);


### PR DESCRIPTION
There was a partial implementation of just the Touch objects. Added the extra scaffolding for the event listeners and tests based on the existing drag tests.